### PR TITLE
Refuse production legacy SPA asset uploads

### DIFF
--- a/docs/cloudflare.md
+++ b/docs/cloudflare.md
@@ -128,7 +128,8 @@ npm run cf:upload-spa-assets -- --bucket <spa-assets-bucket>
 
 The upload command writes `/releases/<release-id>/assets/*` and
 `/releases/<release-id>/manifest.json`. It refuses to update legacy `/assets/*`
-unless `--legacy-stable` is passed explicitly.
+on the production `mojidata-spa-assets` bucket, even when `--legacy-stable` is
+passed. `--legacy-stable` is only for non-production buckets.
 
 Deploy the SPA asset Worker:
 

--- a/scripts/upload-spa-assets-to-r2.mjs
+++ b/scripts/upload-spa-assets-to-r2.mjs
@@ -9,6 +9,7 @@ const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const defaultAssetsDir = path.join(rootDir, 'dist', 'spa-assets')
 const releaseAssetCacheControl = 'public, max-age=31536000, immutable'
 const legacyAssetCacheControl = 'public, max-age=300, must-revalidate'
+const productionSpaAssetBuckets = new Set(['mojidata-spa-assets'])
 
 const assets = [
   { name: 'sql-wasm.wasm', contentType: 'application/wasm' },
@@ -185,12 +186,18 @@ const legacyStable =
   readFlag('legacy-stable') || process.env.MOJIDATA_SPA_R2_LEGACY_STABLE === '1'
 const force = readFlag('force') || process.env.MOJIDATA_SPA_R2_FORCE === '1'
 
-process.env.MOJIDATA_SPA_ASSETS_DIR = assetsDir
-await import('./copy-spa-assets.mjs')
-
 if (!bucket) {
   throw new Error(
     'Set MOJIDATA_SPA_R2_BUCKET or pass --bucket <bucket> before uploading SPA assets to R2.',
+  )
+}
+
+if (release && legacyStable) {
+  throw new Error(
+    [
+      'Refusing ambiguous SPA asset upload options.',
+      'Use --release for release-prefixed assets, or --legacy-stable for non-production legacy stable keys, but not both.',
+    ].join('\n'),
   )
 }
 
@@ -199,10 +206,23 @@ if (!release && !legacyStable) {
     [
       'Refusing to upload mutable stable SPA asset keys by default.',
       'Pass --release <release-id> or set MOJIDATA_SPA_ASSET_RELEASE to upload immutable release assets.',
-      'Pass --legacy-stable only for an explicit legacy /assets/* refresh.',
+      'Pass --legacy-stable only for an explicit non-production legacy /assets/* refresh.',
     ].join('\n'),
   )
 }
+
+if (legacyStable && productionSpaAssetBuckets.has(bucket)) {
+  throw new Error(
+    [
+      `Refusing to upload legacy stable SPA asset keys to production bucket: ${bucket}`,
+      'Production SPA assets must use immutable release keys.',
+      'Set MOJIDATA_SPA_ASSET_RELEASE or pass --release <release-id>.',
+    ].join('\n'),
+  )
+}
+
+process.env.MOJIDATA_SPA_ASSETS_DIR = assetsDir
+await import('./copy-spa-assets.mjs')
 
 if (release && !force) {
   const exists = await commandSucceeds('npx', [


### PR DESCRIPTION
## Summary

- Reject `--legacy-stable` uploads to the production `mojidata-spa-assets` bucket.
- Reject ambiguous `--release` + `--legacy-stable` usage.
- Validate upload mode before generating local SPA assets, so wrong commands fail before any upload work starts.
- Update Cloudflare deployment docs to state that `--legacy-stable` is non-production only.

## Verification

- `node --check scripts/upload-spa-assets-to-r2.mjs`
- `node scripts/upload-spa-assets-to-r2.mjs --bucket mojidata-spa-assets` fails before upload
- `node scripts/upload-spa-assets-to-r2.mjs --bucket mojidata-spa-assets --legacy-stable` fails before upload
- `node scripts/upload-spa-assets-to-r2.mjs --bucket mojidata-spa-assets --release test-release --legacy-stable` fails before upload
- `npm run lint:js -- scripts/upload-spa-assets-to-r2.mjs`

Related: #27